### PR TITLE
Support multiple keys splitted by '||'

### DIFF
--- a/lib/secret_env.rb
+++ b/lib/secret_env.rb
@@ -40,7 +40,7 @@ module SecretEnv
         secret_keys = scanner.matched[2..-2] # Extract "secret" from "\#{secret}"
 
         secret = nil
-        secret_keys.split(/\s*\|\|\s*/).each do |secret_key|
+        secret_keys.split("||").map(&:strip).each do |secret_key|
           secret = case
                    when ENV.has_key?(secret_key)
                      ENV[secret_key]

--- a/lib/secret_env.rb
+++ b/lib/secret_env.rb
@@ -37,20 +37,24 @@ module SecretEnv
       scanner = StringScanner.new(@raw_value)
       parts = []
       while part = scanner.scan_until(/#\{(.*?)\}/)
-        secret_key = scanner.matched[2..-2] # Extract "secret" from "\#{secret}"
+        secret_keys = scanner.matched[2..-2] # Extract "secret" from "\#{secret}"
 
+        secret = nil
+        secret_keys.split(/\s*\|\|\s*/).each do |secret_key|
+          secret = case
+                   when ENV.has_key?(secret_key)
+                     ENV[secret_key]
+                   when @dependency.has_key?(secret_key)
+                     # FIXME this code may cause infinite loop
+                     @dependency[secret_key].value
+                   else
+                     @storage.retrieve(secret_key)
+                   end
 
-        secret = case
-                 when ENV.has_key?(secret_key)
-                   ENV[secret_key]
-                 when @dependency.has_key?(secret_key)
-                   # FIXME this code may cause infinite loop
-                   @dependency[secret_key].value
-                 else
-                   @storage.retrieve(secret_key)
-                 end
+          break if secret
+        end
 
-        raise SecretEnv::KeyNotFound, secret_key unless secret
+        raise SecretEnv::KeyNotFound, secret_keys unless secret
         parts << part.gsub(scanner.matched, secret)
       end
       parts << scanner.rest

--- a/spec/secret_env_spec.rb
+++ b/spec/secret_env_spec.rb
@@ -165,7 +165,7 @@ describe SecretEnv do
                 'env' => {
                   'DB_USER' => 'db_user',
                   'DB_USER2' => 'db_user2',
-                  'DATABASE_URL' => 'mysql2://#{DB_USER || DB_USER2}:#{db_password || db_password2}@#{db_host || db_host2}:3306',
+                  'DATABASE_URL' => 'mysql2://#{DB_USER || DB_USER2}:#{db_password || db_password2}@#{ db_host || db_host2}:3306',
                   'db_host' => 'db_slave',
                   'db_host2' => 'db_slave2'
                 }
@@ -198,7 +198,7 @@ describe SecretEnv do
                 },
                 'env' => {
                   'DB_USER2' => 'db_user2',
-                  'DATABASE_URL' => 'mysql2://#{DB_USER || DB_USER2}:#{db_password || db_password2}@#{db_host || db_host2}:3306',
+                  'DATABASE_URL' => 'mysql2://#{DB_USER || DB_USER2}:#{db_password || db_password2}@#{ db_host || db_host2}:3306',
                   'db_host2' => 'db_slave2'
                 }
               }

--- a/spec/secret_env_spec.rb
+++ b/spec/secret_env_spec.rb
@@ -152,6 +152,81 @@ describe SecretEnv do
           end
         end
       end
+
+      describe 'multiple keys' do
+        context 'when retrieve first key' do
+          let(:yml) do
+            {
+              'development' => {
+                'storage' => {
+                  'type' => 'credstash',
+                  'namespace' => 'myapp.development.'
+                },
+                'env' => {
+                  'DB_USER' => 'db_user',
+                  'DB_USER2' => 'db_user2',
+                  'DATABASE_URL' => 'mysql2://#{DB_USER || DB_USER2}:#{db_password || db_password2}@#{db_host || db_host2}:3306',
+                  'db_host' => 'db_slave',
+                  'db_host2' => 'db_slave2'
+                }
+              }
+            }
+          end
+
+          before do
+            allow(::CredStash).to receive(:get).and_return(nil)
+            allow(::CredStash).to receive(:get).with('myapp.development.db_password').and_return('secret_password')
+            allow(::CredStash).to receive(:get).with('myapp.development.db_password2').and_return('secret_password2')
+          end
+
+          it 'retrieve by second key' do
+            expect {
+              SecretEnv.load
+            }.to change {
+              ENV['DATABASE_URL']
+            }.from(nil).to('mysql2://db_user:secret_password@db_slave:3306')
+          end
+        end
+
+        context 'when retrieve second key' do
+          let(:yml) do
+            {
+              'development' => {
+                'storage' => {
+                  'type' => 'credstash',
+                  'namespace' => 'myapp.development.'
+                },
+                'env' => {
+                  'DB_USER2' => 'db_user2',
+                  'DATABASE_URL' => 'mysql2://#{DB_USER || DB_USER2}:#{db_password || db_password2}@#{db_host || db_host2}:3306',
+                  'db_host2' => 'db_slave2'
+                }
+              }
+            }
+          end
+
+          before do
+            allow(::CredStash).to receive(:get).and_return(nil)
+            allow(::CredStash).to receive(:get).with('myapp.development.db_password2').and_return('secret_password2')
+          end
+
+          it 'retrieve by first key' do
+            expect {
+              SecretEnv.load
+            }.to change {
+              ENV['DATABASE_URL']
+            }.from(nil).to('mysql2://db_user2:secret_password2@db_slave2:3306')
+          end
+        end
+
+        after do
+          ENV['DB_USER'] = nil
+          ENV['DB_USER2'] = nil
+          ENV['db_host'] = nil
+          ENV['db_host2'] = nil
+          ENV['DATABASE_URL'] = nil
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Add support for multiple keys:

```ruby
ENV['DB_USER'] = nil
ENV['DB_USER2'] = "db_user2"

# "#{DB_USER || DB_USER2}@..." => "db_user2@..."
```
