### PR TITLE
Set env by environment varialbe

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ bar=2
 
     $ secret_env config/secret_env.yml production your_command --option
 
+or
+
+    $ export SECRET_ENV=production
+    $ secret_env config/secret_env.yml your_command --option
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/adorechic/secret_env.

--- a/exe/secret_env
+++ b/exe/secret_env
@@ -3,7 +3,14 @@
 require "secret_env"
 require 'open3'
 config, env = ARGV.shift(2)
-SecretEnv.load(env: env, secrets_file: config)
+
+if SecretEnv.env?(env: env, secrets_file: config)
+  SecretEnv.load(env: env, secrets_file: config)
+else
+  SecretEnv.load(env: ENV['SECRET_ENV'], secrets_file: config)
+  ARGV.unshift(env)
+end
+
 stdin, stdoe, t = Open3.popen2e(*ARGV)
 stdin.close
 stdoe.each do |line|

--- a/lib/secret_env.rb
+++ b/lib/secret_env.rb
@@ -21,6 +21,10 @@ module SecretEnv
     end
   end
 
+  def self.env?(env: 'development', secrets_file: 'config/secret_env.yml')
+    YAML.load_file(secrets_file).key?(env)
+  end
+
   class Record
     attr_reader :key
 

--- a/spec/secret_env_spec.rb
+++ b/spec/secret_env_spec.rb
@@ -47,6 +47,28 @@ describe SecretEnv do
     end
   end
 
+  describe '.env?' do
+    before do
+      expect(YAML).to receive(:load_file).with('config/secret_env.yml').and_return(yml)
+    end
+
+    let(:yml) do
+      {
+        'development' => {}
+      }
+    end
+
+    it 'exists' do
+      expect(SecretEnv.env?).to be_truthy
+    end
+
+    context 'without envs' do
+      it 'dose not exit' do
+        expect(SecretEnv.env?(env: 'production')).to be_falsey
+      end
+    end
+  end
+
   describe SecretEnv::Record do
     it 'extracts secrets and combines them' do
       [


### PR DESCRIPTION
I use `CMD secret_env config/secret_env.yml production your_command --option` in DockerFile to dynamically changing `production` to `development`.  
But `CMD` in DockerFile can't use  environment variable.  

Switch with `docker run --env SECRET_ENV=xxx`.

```
export SECRET_ENV=development
secret_env config/secret_env.yml your_command --option
```